### PR TITLE
Create a Book and BookCopy custom objects

### DIFF
--- a/force-app/main/default/layouts/BookCopy__c-Book Copy Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/BookCopy__c-Book Copy Layout.layout-meta.xml
@@ -11,28 +11,11 @@
                 <field>Name</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Author__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Edition__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Description__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>ISBN__c</field>
+                <behavior>Required</behavior>
+                <field>Book__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>OwnerId</field>
-            </layoutItems>
-        </layoutColumns>
+        <layoutColumns/>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -63,10 +46,6 @@
         <layoutColumns/>
         <style>CustomLinks</style>
     </layoutSections>
-    <relatedLists>
-        <fields>NAME</fields>
-        <relatedList>Book_Copy__c.Book__c</relatedList>
-    </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
     <showHighlightsPanel>false</showHighlightsPanel>
     <showInteractionLogPanel>false</showInteractionLogPanel>

--- a/force-app/main/default/layouts/Book_Copy__c-Book Copy Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Book_Copy__c-Book Copy Layout.layout-meta.xml
@@ -7,32 +7,15 @@
         <label>Information</label>
         <layoutColumns>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Readonly</behavior>
                 <field>Name</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Author__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Edition__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Description__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>ISBN__c</field>
+                <behavior>Required</behavior>
+                <field>Book__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>OwnerId</field>
-            </layoutItems>
-        </layoutColumns>
+        <layoutColumns/>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -63,10 +46,6 @@
         <layoutColumns/>
         <style>CustomLinks</style>
     </layoutSections>
-    <relatedLists>
-        <fields>NAME</fields>
-        <relatedList>Book_Copy__c.Book__c</relatedList>
-    </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
     <showHighlightsPanel>false</showHighlightsPanel>
     <showInteractionLogPanel>false</showInteractionLogPanel>

--- a/force-app/main/default/objects/Book_Copy__c/Book_Copy__c.object-meta.xml
+++ b/force-app/main/default/objects/Book_Copy__c/Book_Copy__c.object-meta.xml
@@ -143,7 +143,7 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <description>Book meta-information</description>
+    <description>This object holds the information about the physical book meaning one instance of Book custom object</description>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -153,13 +153,14 @@
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <label>Book</label>
+    <label>Book Copy</label>
     <nameField>
-        <label>Title</label>
-        <type>Text</type>
+        <displayFormat>copy-{0}</displayFormat>
+        <label>Book Copy ID</label>
+        <type>AutoNumber</type>
     </nameField>
-    <pluralLabel>Books</pluralLabel>
+    <pluralLabel>Book Copies</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ReadWrite</sharingModel>
+    <sharingModel>ControlledByParent</sharingModel>
     <visibility>Public</visibility>
 </CustomObject>

--- a/force-app/main/default/objects/Book_Copy__c/fields/Book__c.field-meta.xml
+++ b/force-app/main/default/objects/Book_Copy__c/fields/Book__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Book__c</fullName>
+    <description>This is a related list which shows the list of Books</description>
+    <externalId>false</externalId>
+    <label>Book</label>
+    <referenceTo>Book__c</referenceTo>
+    <relationshipLabel>Book Copies</relationshipLabel>
+    <relationshipName>Book_Copies</relationshipName>
+    <relationshipOrder>0</relationshipOrder>
+    <reparentableMasterDetail>false</reparentableMasterDetail>
+    <trackTrending>false</trackTrending>
+    <type>MasterDetail</type>
+    <writeRequiresMasterRead>false</writeRequiresMasterRead>
+</CustomField>

--- a/force-app/main/default/objects/Book_Copy__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/Book_Copy__c/listViews/All.listView-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <filterScope>Everything</filterScope>
+    <label>All</label>
+</ListView>

--- a/force-app/main/default/objects/Book__c/Book__c.object-meta.xml
+++ b/force-app/main/default/objects/Book__c/Book__c.object-meta.xml
@@ -143,7 +143,7 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <description>Book meta-information.</description>
+    <description>Book meta-information</description>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -155,7 +155,7 @@
     <enableStreamingApi>true</enableStreamingApi>
     <label>Book</label>
     <nameField>
-        <label>Title</label>
+        <label>Book Name</label>
         <type>Text</type>
     </nameField>
     <pluralLabel>Books</pluralLabel>

--- a/force-app/main/default/objects/Book__c/fields/Author__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Author__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Author__c</fullName>
+    <description>This field gives the name of the author</description>
+    <externalId>false</externalId>
+    <label>Author</label>
+    <length>30</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/Description__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Description__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Description__c</fullName>
+    <description>This describes the content or the description of the physical book</description>
+    <externalId>false</externalId>
+    <label>Description</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>TextArea</type>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/Edition__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Edition__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Edition__c</fullName>
+    <description>This field gives the Edition of the book</description>
+    <externalId>false</externalId>
+    <label>Edition</label>
+    <length>30</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/ISBN__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/ISBN__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ISBN__c</fullName>
+    <description>This field is number that&#39;s used as a unique identifier for books internationally</description>
+    <externalId>false</externalId>
+    <label>ISBN</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/tabs/Book_Copy__c.tab-meta.xml
+++ b/force-app/main/default/tabs/Book_Copy__c.tab-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <motif>Custom50: Big top</motif>
+</CustomTab>


### PR DESCRIPTION

Implemented the data model for Book and BookCopy custom Object, 
- created a master-detail relationship between them where Book being parent and BookCopy being the child 

- created custom fields for Book and BookCopy objects

- created one instance for Book and one instance for BookCopy for testing 